### PR TITLE
Update to ConfigMe 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>ch.jalu</groupId>
             <artifactId>configme</artifactId>
-            <version>0.4</version>
+            <version>1.0.1</version>
         </dependency>
 
         <!-- Dependency Injector -->

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/configuration/PlayerSettings.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/configuration/PlayerSettings.kt
@@ -1,8 +1,8 @@
 package me.ebonjaeger.perworldinventory.configuration
 
 import ch.jalu.configme.Comment
-import ch.jalu.configme.SectionComments
 import ch.jalu.configme.SettingsHolder
+import ch.jalu.configme.configurationdata.CommentsConfiguration
 import ch.jalu.configme.properties.Property
 import ch.jalu.configme.properties.PropertyInitializer.newProperty
 
@@ -81,14 +81,8 @@ object PlayerSettings : SettingsHolder
     @Comment("Load the current remaining air a player has")
     val LOAD_REMAINING_AIR: Property<Boolean>? = newProperty("player.stats.remaining-air", true)
 
-    @JvmStatic
-    @SectionComments
-    fun buildSectionComments(): MutableMap<String, Array<out String>>
-    {
-        val comments = HashMap<String, Array<out String>>()
-        comments["player"] = arrayOf("All settings for players are here:")
-        comments["player.stats"] = arrayOf("All options for player stats are here:")
-
-        return comments
+    override fun registerComments(conf: CommentsConfiguration) {
+        conf.setComment("player", "All settings for players are here:")
+        conf.setComment("player.stats", "All options for player stats are here:")
     }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/configuration/Settings.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/configuration/Settings.kt
@@ -1,7 +1,9 @@
 package me.ebonjaeger.perworldinventory.configuration
 
 import ch.jalu.configme.SettingsHolder
-import ch.jalu.configme.SettingsManager
+import ch.jalu.configme.SettingsManagerImpl
+import ch.jalu.configme.configurationdata.ConfigurationData
+import ch.jalu.configme.configurationdata.ConfigurationDataBuilder
 import ch.jalu.configme.migration.MigrationService
 import ch.jalu.configme.resource.YamlFileResource
 import java.io.File
@@ -9,14 +11,14 @@ import java.io.File
 /**
  * Settings class for PWI settings.
  *
- * @param file The configuration file to load
+ * @param resource The property resource to read from and write to
  * @param migrater The configuration migrater to use to add new config options
  * @param settingsHolders Classes that hold the actual properties
  */
-class Settings private constructor(file: YamlFileResource,
-                                   migrater: MigrationService,
-                                   vararg settingsHolders: Class<out SettingsHolder>) :
-        SettingsManager(file, migrater, *settingsHolders)
+class Settings private constructor(resource: YamlFileResource,
+                                   configurationData: ConfigurationData,
+                                   migrater: MigrationService) :
+        SettingsManagerImpl(resource, configurationData, migrater)
 {
 
     companion object {
@@ -35,9 +37,10 @@ class Settings private constructor(file: YamlFileResource,
          */
         fun create(file: File): Settings {
             val fileResource = YamlFileResource(file)
+            val configurationData = ConfigurationDataBuilder.createConfiguration(*PROPERTY_HOLDERS)
             val migrater = PwiMigrationService()
 
-            return Settings(fileResource, migrater, *PROPERTY_HOLDERS)
+            return Settings(fileResource, configurationData, migrater)
         }
     }
 }


### PR DESCRIPTION
This PR updates your ConfigMe version to 1.0.1. 

https://github.com/AuthMe/ConfigMe/blob/master/CHANGELOG.md

The biggest difference to keep in mind now is that PropertyReader is now immutable and offers a "snapshot" of the file (it cannot be reloaded). The values of properties are now being managed in ConfigurationData instead, so in the migration service we'll be reading from PropertyReader and writing to ConfigurationData. Previously both reading & managing values was being done in PropertyResource.