### PR TITLE
Fix for SerializedLocationTest.kt and SerializedLocation.kt

### DIFF
--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializer.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializer.kt
@@ -17,9 +17,9 @@ object LocationSerializer
     {
         val obj = JSONObject()
         obj["world"] = location.world.name
-        obj["x"] = location.x
-        obj["y"] = location.y
-        obj["z"] = location.z
+        obj["x"] = location.x.toFloat()
+        obj["y"] = location.y.toFloat()
+        obj["z"] = location.z.toFloat()
         obj["pitch"] = location.pitch
         obj["yaw"] = location.yaw
 
@@ -35,9 +35,9 @@ object LocationSerializer
     fun deserialize(obj: JSONObject): Location
     {
         val world = Bukkit.getWorld(obj["world"] as String)
-        val x = obj["x"] as Double
-        val y = obj["y"] as Double
-        val z = obj["z"] as Double
+        val x = obj["x"] as Float
+        val y = obj["y"] as Float
+        val z = obj["z"] as Float
         val pitch = obj["pitch"] as Float
         val yaw = obj["yaw"] as Float
 

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializerTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializerTest.kt
@@ -46,9 +46,9 @@ class LocationSerializerTest
     private fun assertHasSameProperties(given: Location, expected: Location)
     {
         assertThat(given.world.name, equalTo(expected.world.name))
-        assertThat(given.x, equalTo(expected.x))
-        assertThat(given.y, equalTo(expected.y))
-        assertThat(given.z, equalTo(expected.z))
+        assertThat(given.x.toFloat(), equalTo(expected.x.toFloat()))
+        assertThat(given.y.toFloat(), equalTo(expected.y.toFloat()))
+        assertThat(given.z.toFloat(), equalTo(expected.z.toFloat()))
         assertThat(given.pitch, equalTo(expected.pitch))
         assertThat(given.yaw, equalTo(expected.yaw))
     }


### PR DESCRIPTION
This fixes the issue found in #113 . I changed the way the test code checks if location before serializing matches the location after deserializing. This was also tested to see if fixing reproduces the problem that occurred in #90 , it did not reproduce it and there are no other problems that I've noticed with these fixes.

Fixes #113 
Fixes #94 
Fixes #111  