### PR TITLE
1.14 update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <!-- Project properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.jdkVersion>1.8</project.jdkVersion>
-        <kotlin.version>1.3.30</kotlin.version>
+        <kotlin.version>1.3.31</kotlin.version>
 
         <!-- Output properties -->
         <project.outputName>PerWorldInventory</project.outputName>
@@ -440,6 +440,26 @@
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
                 <version>2.20.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <bukkitplugin.authors>EbonJaeger</bukkitplugin.authors>
 
         <!-- Change Bukkit Version HERE! -->
-        <bukkit.version>1.14-pre5-SNAPSHOT</bukkit.version>
+        <bukkit.version>1.14-R0.1-SNAPSHOT</bukkit.version>
         <powermock.version>1.7.3</powermock.version>
     </properties>
 
@@ -241,13 +241,13 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>
-            <version>1.2.20</version>
+            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit</artifactId>
-            <version>1.2.20</version>
+            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <!-- Project properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.jdkVersion>1.8</project.jdkVersion>
-        <kotlin.version>1.3.11</kotlin.version>
+        <kotlin.version>1.3.30</kotlin.version>
 
         <!-- Output properties -->
         <project.outputName>PerWorldInventory</project.outputName>
@@ -31,7 +31,7 @@
         <bukkitplugin.authors>EbonJaeger</bukkitplugin.authors>
 
         <!-- Change Bukkit Version HERE! -->
-        <bukkit.version>1.13-R0.1-SNAPSHOT</bukkit.version>
+        <bukkit.version>1.14-pre5-SNAPSHOT</bukkit.version>
         <powermock.version>1.7.3</powermock.version>
     </properties>
 

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
@@ -109,7 +109,13 @@ class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
         bukkitService.runTaskAsynchronously {
             val yaml = YamlConfiguration.loadConfiguration(WORLDS_CONFIG_FILE)
             bukkitService.runTask {
-                yaml.getConfigurationSection("groups.").getKeys(false).forEach { key ->
+                var section = yaml.getConfigurationSection("groups.")
+
+                if (section == null) { // Ensure the file contains the groups section
+                    section = yaml.createSection("groups")
+                }
+
+                section.getKeys(false).forEach { key ->
                     val worlds = yaml.getStringList("groups.$key.worlds").toMutableSet()
                     val gameMode = GameMode.valueOf( (yaml.getString("groups.$key.default-gamemode") ?: "SURVIVAL").toUpperCase() )
                     val respawnWorld = if (yaml.contains("groups.$key.respawnWorld"))

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
@@ -54,7 +54,7 @@ class PerWorldInventory : JavaPlugin
     constructor(): super()
 
     /* Constructor used for tests. */
-    internal constructor(loader: JavaPluginLoader, description: PluginDescriptionFile, dataFolder: File, file: File?)
+    internal constructor(loader: JavaPluginLoader, description: PluginDescriptionFile, dataFolder: File, file: File)
             : super(loader, description, dataFolder, file)
 
     override fun onEnable()

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommands.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommands.kt
@@ -32,20 +32,26 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
     @CommandPermission("perworldinventory.command.groups.info")
     @Description("Display information about a group")
     @CommandCompletion("@groups")
-    fun onGroupInfo(sender: CommandSender, @Optional groupName: String)
+    fun onGroupInfo(sender: CommandSender, @Optional groupName: String?)
     {
         var group: Group? = null
         if (groupName !== null)
         {
             group = groupManager.getGroup(groupName)
-
         }
 
         if (group === null)
         {
             if (sender is Player)
             {
-                group = groupManager.getGroupFromWorld(sender.location.world.name)
+                val world = sender.location.world
+
+                if (world == null) {
+                    sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}Unable to get the world from your location!")
+                    return
+                }
+
+                group = groupManager.getGroupFromWorld(world.name)
             } else
             {
                 sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}Unknown group '$groupName'!")
@@ -95,7 +101,7 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
     @CommandPermission("perworldinventory.command.groups.modify")
     @Description("Add a world to a group")
     @CommandCompletion("@groups @worlds")
-    fun onAddWorld(sender: CommandSender, groupName: String, @Optional world: String)
+    fun onAddWorld(sender: CommandSender, groupName: String, @Optional world: String?)
     {
         val group = groupManager.getGroup(groupName)
 
@@ -109,12 +115,12 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
         var worldName = world
 
         // Check if the sender specified a world, and if that world exists
-        if (world != null && Bukkit.getWorld(world) == null)
+        if (worldName != null && Bukkit.getWorld(worldName) == null)
         {
             // User specified a world, but it doesn't exist
             sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}No world with that name exists!")
             return
-        } else if (world == null) // Else, get the world from the sender's current location
+        } else if (worldName == null) // Else, get the world from the sender's current location
         {
             if (sender !is Player)
             {
@@ -122,7 +128,14 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
                 return
             }
 
-            worldName = sender.location.world.name
+            val playerWorld = sender.location.world
+
+            if (playerWorld == null) {
+                sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}Unable to get the world from your location!")
+                return
+            }
+
+            worldName = playerWorld.name
         }
 
         group.addWorld(worldName)
@@ -151,7 +164,7 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
     @CommandPermission("perworldinventory.command.groups.modify")
     @Description("Remove a world from a group")
     @CommandCompletion("@groups @worlds")
-    fun onRemoveWorld(sender: CommandSender, groupName: String, @Optional world: String)
+    fun onRemoveWorld(sender: CommandSender, groupName: String, @Optional world: String?)
     {
         val group = groupManager.getGroup(groupName)
 
@@ -165,12 +178,12 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
         var worldName = world
 
         // Check if the sender specified a world, and if that world exists
-        if (world != null && Bukkit.getWorld(world) == null)
+        if (worldName != null && Bukkit.getWorld(worldName) == null)
         {
             // User specified a world, but it doesn't exist
             sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}No world with that name exists!")
             return
-        } else if (world == null) // Else, get the world from the sender's current location
+        } else if (worldName == null) // Else, get the world from the sender's current location
         {
             if (sender !is Player)
             {
@@ -178,7 +191,14 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
                 return
             }
 
-            worldName = sender.location.world.name
+            val playerWorld = sender.location.world
+
+            if (playerWorld == null) {
+                sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}Unable to get the world from your location!")
+                return
+            }
+
+            worldName = playerWorld.name
         }
 
         // Make sure the group actually has the world in it
@@ -197,7 +217,7 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
     @CommandPermission("perworldinventory.command.groups.modify")
     @Description("Set the default spawn world for a group")
     @CommandCompletion("@groups @worlds")
-    fun onSetRespawnWorld(sender: CommandSender, groupName: String, @Optional world: String)
+    fun onSetRespawnWorld(sender: CommandSender, groupName: String, @Optional world: String?)
     {
         val group = groupManager.getGroup(groupName)
 
@@ -211,12 +231,12 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
         var worldName = world
 
         // Check if the sender specified a world, and if that world exists
-        if (world != null && Bukkit.getWorld(world) == null)
+        if (worldName != null && Bukkit.getWorld(worldName) == null)
         {
             // User specified a world, but it doesn't exist
             sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}No world with that name exists!")
             return
-        } else if (world == null) // Else, get the world from the sender's current location
+        } else if (worldName == null) // Else, get the world from the sender's current location
         {
             if (sender !is Player)
             {
@@ -224,7 +244,14 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
                 return
             }
 
-            worldName = sender.location.world.name
+            val playerWorld = sender.location.world
+
+            if (playerWorld == null) {
+                sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}Unable to get the world from your location!")
+                return
+            }
+
+            worldName = playerWorld.name
         }
 
         // Make sure the group actually has the world in it

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/FlatFile.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/FlatFile.kt
@@ -78,7 +78,7 @@ class FlatFile @Inject constructor(@DataDirectory private val dataDirectory: Fil
         {
             createFileIfNotExists(file)
             val data = LocationSerializer.serialize(location)
-            val key = location.world?.name
+            val key = location.world!!.name // The server will never provide a null world in a Location
 
             // Get any existing data
             val parser = JSONParser(JSONParser.USE_INTEGER_STORAGE)

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/FlatFile.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/FlatFile.kt
@@ -78,7 +78,7 @@ class FlatFile @Inject constructor(@DataDirectory private val dataDirectory: Fil
         {
             createFileIfNotExists(file)
             val data = LocationSerializer.serialize(location)
-            val key = location.world.name
+            val key = location.world?.name
 
             // Get any existing data
             val parser = JSONParser(JSONParser.USE_INTEGER_STORAGE)

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/FlatFile.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/FlatFile.kt
@@ -82,8 +82,8 @@ class FlatFile @Inject constructor(@DataDirectory private val dataDirectory: Fil
 
             // Get any existing data
             val parser = JSONParser(JSONParser.USE_INTEGER_STORAGE)
-            FileReader(file).use {
-                val root = parser.parse(it) as JSONObject
+            FileReader(file).use { reader ->
+                val root = parser.parse(reader) as JSONObject
                 val locations = if (root.containsKey("locations"))
                 {
                     root["locations"] as JSONObject
@@ -101,7 +101,7 @@ class FlatFile @Inject constructor(@DataDirectory private val dataDirectory: Fil
                 // Write the latest data to disk
                 locations[key] = data
                 root["locations"] = locations
-                FileWriter(file).use { it.write(root.toJSONString(JSONStyle.LT_COMPRESS)) }
+                FileWriter(file).use { writer -> writer.write(root.toJSONString(JSONStyle.LT_COMPRESS)) }
             }
         } catch (ex: IOException)
         {

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/PlayerProfile.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/PlayerProfile.kt
@@ -39,11 +39,10 @@ data class PlayerProfile constructor(val armor: Array<out ItemStack>,
      *
      * @param player The player to build this profile from
      * @param balance The amount of currency the player has
-     * @param useAttributes If the [Attribute] class should be used for max health
      */
     constructor(player: Player,
-                balance: Double,
-                useAttributes: Boolean) : this(player.inventory.armorContents,
+                balance: Double) : this(
+            player.inventory.armorContents,
             player.enderChest.contents,
             player.inventory.contents,
             player.allowFlight,
@@ -52,7 +51,7 @@ data class PlayerProfile constructor(val armor: Array<out ItemStack>,
             player.exp,
             player.isFlying,
             player.foodLevel,
-            if (useAttributes) player.getAttribute(Attribute.GENERIC_MAX_HEALTH).baseValue else player.maxHealth,
+            player.getAttribute(Attribute.GENERIC_MAX_HEALTH)!!.baseValue, // If this is ever null, I will be very surprised
             player.health,
             player.gameMode,
             player.level,

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileFactory.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileFactory.kt
@@ -18,6 +18,6 @@ class ProfileFactory @Inject constructor(private val bukkitService: BukkitServic
     fun create(player: Player): PlayerProfile
     {
         val balance = economyService.getBalance(player)
-        return PlayerProfile(player, balance, bukkitService.shouldUseAttributes())
+        return PlayerProfile(player, balance)
     }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileManager.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileManager.kt
@@ -139,7 +139,7 @@ class ProfileManager @Inject constructor(private val bukkitService: BukkitServic
         {
             player.inventory.clear()
             player.inventory.contents = profile.inventory
-            player.inventory.armorContents = profile.armor
+            player.inventory.setArmorContents(profile.armor)
         }
         if (settings.getProperty(PlayerSettings.LOAD_ENDER_CHEST))
         {
@@ -154,11 +154,7 @@ class ProfileManager @Inject constructor(private val bukkitService: BukkitServic
             return
         }
 
-        if (bukkitService.shouldUseAttributes()) {
-            player.getAttribute(Attribute.GENERIC_MAX_HEALTH).baseValue = profile.maxHealth
-        } else {
-            player.maxHealth = profile.maxHealth
-        }
+        player.getAttribute(Attribute.GENERIC_MAX_HEALTH)!!.baseValue = profile.maxHealth // Players have max health, this wont be null
 
         if (profile.health > 0 && profile.health <= profile.maxHealth) {
             player.health = profile.health
@@ -226,13 +222,7 @@ class ProfileManager @Inject constructor(private val bukkitService: BukkitServic
         }
         if (settings.getProperty(PlayerSettings.LOAD_HEALTH))
         {
-            if (bukkitService.shouldUseAttributes())
-            {
-                player.getAttribute(Attribute.GENERIC_MAX_HEALTH).baseValue = PlayerDefaults.HEALTH
-            } else
-            {
-                player.maxHealth = PlayerDefaults.HEALTH
-            }
+            player.getAttribute(Attribute.GENERIC_MAX_HEALTH)!!.baseValue = PlayerDefaults.HEALTH // Players have max health, this wont be null
             player.health = PlayerDefaults.HEALTH
         }
         if (settings.getProperty(PlayerSettings.LOAD_LEVEL))

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/entity/EntityPortalEventListener.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/entity/EntityPortalEventListener.kt
@@ -18,23 +18,24 @@ class EntityPortalEventListener @Inject constructor(private val groupManager: Gr
         if (event.entity !is Item)
             return
 
-        ConsoleLogger.fine("[ENTITYPORTALEVENT] A '${event.entity.name}' is going through a portal")
+        ConsoleLogger.fine("[EntityPortalEvent] A '${event.entity.name}' is going through a portal")
 
-        val worldFrom = event.from.world.name
+        val worldFrom = event.from.world
+        val locationTo = event.to ?: return // A destination location is not guaranteed to exist
+        val worldTo = locationTo.world
 
-        if (event.to == null || event.to.world == null)
-        {
-            ConsoleLogger.debug("[ENTITYPORTALEVENT] event.getTo().getWorld().getName() would throw a NPE! Exiting method!")
+        if (worldFrom == null || worldTo == null) {
+            ConsoleLogger.fine("[EntityPortalEvent] One of the worlds was null, returning")
             return
         }
-        val worldTo = event.to.world.name
-        val from = groupManager.getGroupFromWorld(worldFrom)
-        val to = groupManager.getGroupFromWorld(worldTo)
+
+        val from = groupManager.getGroupFromWorld(worldFrom.name)
+        val to = groupManager.getGroupFromWorld(worldTo.name)
 
         // If the groups are different, cancel the event
         if (from != to)
         {
-            ConsoleLogger.debug("[ENTITYPORTALEVENT] Group '${from.name}' and group '${to.name}' are different! Canceling event!")
+            ConsoleLogger.debug("[EntityPortalEvent] Group '${from.name}' and group '${to.name}' are different! Canceling event!")
             event.isCancelled = true
         }
     }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerDeathListener.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerDeathListener.kt
@@ -21,7 +21,8 @@ class PlayerDeathListener @Inject constructor(private val groupManager: GroupMan
     fun onPlayerDeath(event: PlayerDeathEvent)
     {
         val player = event.entity
-        val group = groupManager.getGroupFromWorld(player.location.world.name)
+        val location = player.location
+        val group = groupManager.getGroupFromWorld(location.world!!.name)
 
         if (!event.keepInventory)
         {

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerQuitListener.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerQuitListener.kt
@@ -23,7 +23,7 @@ class PlayerQuitListener @Inject constructor(private val plugin: PerWorldInvento
         plugin.timeouts.remove(event.player.uniqueId)
 
         val player = event.player
-        val group = groupManager.getGroupFromWorld(player.location.world.name)
+        val group = groupManager.getGroupFromWorld(player.location.world!!.name) // The server will never provide a null world in a Location
 
         dataSource.saveLogout(player)
         profileManager.addPlayerProfile(player, group, player.gameMode)
@@ -35,7 +35,7 @@ class PlayerQuitListener @Inject constructor(private val plugin: PerWorldInvento
         plugin.timeouts.remove(event.player.uniqueId)
 
         val player = event.player
-        val group = groupManager.getGroupFromWorld(player.location.world.name)
+        val group = groupManager.getGroupFromWorld(player.location.world!!.name) // The server will never provide a null world in a Location
 
         dataSource.saveLogout(player)
         profileManager.addPlayerProfile(player, group, player.gameMode)

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerRespawnListener.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerRespawnListener.kt
@@ -22,7 +22,7 @@ class PlayerRespawnListener @Inject constructor(private val groupManager: GroupM
     {
         if (!settings.getProperty(PluginSettings.MANAGE_DEATH_RESPAWN)) return
 
-        val group = groupManager.getGroupFromWorld(event.player.location.world.name)
+        val group = groupManager.getGroupFromWorld(event.player.location.world!!.name) // The server will never provide a null world in a Location
         val respawnWorld = group.respawnWorld
         if (respawnWorld != null && group.containsWorld(respawnWorld)) {
             event.respawnLocation = Bukkit.getWorld(respawnWorld).spawnLocation

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerRespawnListener.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerRespawnListener.kt
@@ -1,5 +1,6 @@
 package me.ebonjaeger.perworldinventory.listener.player
 
+import me.ebonjaeger.perworldinventory.ConsoleLogger
 import me.ebonjaeger.perworldinventory.GroupManager
 import me.ebonjaeger.perworldinventory.configuration.PluginSettings
 import me.ebonjaeger.perworldinventory.configuration.Settings
@@ -25,7 +26,14 @@ class PlayerRespawnListener @Inject constructor(private val groupManager: GroupM
         val group = groupManager.getGroupFromWorld(event.player.location.world!!.name) // The server will never provide a null world in a Location
         val respawnWorld = group.respawnWorld
         if (respawnWorld != null && group.containsWorld(respawnWorld)) {
-            event.respawnLocation = Bukkit.getWorld(respawnWorld).spawnLocation
+            val world = Bukkit.getWorld(respawnWorld)
+
+            if (world == null) {
+                ConsoleLogger.warning("Unable to set respawn location: World '$respawnWorld' doesn't exist!")
+                return
+            }
+
+            event.respawnLocation = world.spawnLocation
         }
     }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerSpawnLocationListener.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerSpawnLocationListener.kt
@@ -25,27 +25,28 @@ class PlayerSpawnLocationListener @Inject constructor(private val dataSource: Da
             return
 
         val player = event.player
-        val spawnWorld = event.spawnLocation.world.name
+        val spawnWorld = event.spawnLocation.world!!.name // The server will never provide a null world in a Location
         ConsoleLogger.fine("onPlayerSpawn: '${player.name}' joining in world '$spawnWorld'")
 
         val location = dataSource.getLogout(player)
-        if (location != null && location.world != null)
-        {
-            ConsoleLogger.debug("onPlayerSpawn: Logout location found for player '${player.name}': $location")
 
-            if (location.world.name != spawnWorld)
-            {
-                val spawnGroup = groupManager.getGroupFromWorld(spawnWorld)
-                val logoutGroup = groupManager.getGroupFromWorld(location.world.name)
+        if (location == null || location.world == null) { // No valid location found
+            return
+        }
 
-                if (spawnGroup != logoutGroup)
-                {
-                    ConsoleLogger.fine("onPlayerSpawn: Current group does not match logout group for '${player.name}'")
-                    ConsoleLogger.debug("onPlayerSpawn: spawnGroup=$spawnGroup, logoutGroup=$logoutGroup")
+        ConsoleLogger.debug("onPlayerSpawn: Logout location found for player '${player.name}': $location")
 
-                    profileManager.addPlayerProfile(player, logoutGroup, player.gameMode)
-                    profileManager.getPlayerData(player, spawnGroup, player.gameMode)
-                }
+        val world = location.world
+        if (world!!.name != spawnWorld) { // We saved this Location, so we can assume it has a world
+            val spawnGroup = groupManager.getGroupFromWorld(spawnWorld)
+            val logoutGroup = groupManager.getGroupFromWorld(world.name)
+
+            if (spawnGroup != logoutGroup) {
+                ConsoleLogger.fine("onPlayerSpawn: Current group does not match logout group for '${player.name}'")
+                ConsoleLogger.debug("onPlayerSpawn: spawnGroup=$spawnGroup, logoutGroup=$logoutGroup")
+
+                profileManager.addPlayerProfile(player, logoutGroup, player.gameMode)
+                profileManager.getPlayerData(player, spawnGroup, player.gameMode)
             }
         }
     }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerTeleportListener.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerTeleportListener.kt
@@ -16,14 +16,16 @@ class PlayerTeleportListener @Inject constructor(private val groupManager: Group
     @EventHandler(priority = EventPriority.MONITOR)
     fun onPlayerTeleport(event: PlayerTeleportEvent)
     {
-        if (event.isCancelled || event.from.world == event.to.world)
+        val destination = event.to ?: return // Why is it even possible for the destination to be null?
+
+        if (event.isCancelled || event.from.world == destination.world)
         {
             return
         }
 
         val player = event.player
-        val worldFromName = event.from.world.name
-        val worldToName = event.to.world.name
+        val worldFromName = event.from.world!!.name // The server will never provide a null world in a Location
+        val worldToName = destination.world!!.name // The server will never provide a null world in a Location
         val groupFrom = groupManager.getGroupFromWorld(worldFromName)
         val groupTo = groupManager.getGroupFromWorld(worldToName)
 

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/EconomySerializer.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/EconomySerializer.kt
@@ -2,6 +2,7 @@ package me.ebonjaeger.perworldinventory.serialization
 
 import me.ebonjaeger.perworldinventory.data.PlayerProfile
 import net.minidev.json.JSONObject
+import org.bukkit.util.NumberConversions
 
 object EconomySerializer
 {
@@ -28,7 +29,7 @@ object EconomySerializer
     {
         if (data.containsKey("balance"))
         {
-            return (data["balance"] as Float).toDouble()
+            return NumberConversions.toDouble(data["balance"])
         }
 
         return 0.0

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/ItemSerializer.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/ItemSerializer.kt
@@ -93,16 +93,15 @@ object ItemSerializer
 
     private fun decodeItem(encoded: String): ItemStack
     {
+        if (encoded == AIR)
+        {
+            return ItemStack(Material.AIR)
+        }
+
         try
         {
-            if (encoded == AIR)
-            {
-                return ItemStack(Material.AIR)
-            } else
-            {
-                ByteArrayInputStream(Base64Coder.decodeLines(encoded)).use {
-                    BukkitObjectInputStream(it).use { return it.readObject() as ItemStack }
-                }
+            ByteArrayInputStream(Base64Coder.decodeLines(encoded)).use { byteStream ->
+                BukkitObjectInputStream(byteStream).use { return it.readObject() as ItemStack }
             }
         } catch (ex: IOException)
         {

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializer.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializer.kt
@@ -16,7 +16,7 @@ object LocationSerializer
     fun serialize(location: Location): JSONObject
     {
         val obj = JSONObject()
-        obj["world"] = location.world.name
+        obj["world"] = location.world?.name
         obj["x"] = location.x.toFloat()
         obj["y"] = location.y.toFloat()
         obj["z"] = location.z.toFloat()

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializer.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializer.kt
@@ -16,7 +16,7 @@ object LocationSerializer
     fun serialize(location: Location): JSONObject
     {
         val obj = JSONObject()
-        obj["world"] = location.world?.name
+        obj["world"] = location.world!!.name // The server will never provide a null world in a Location
         obj["x"] = location.x.toFloat()
         obj["y"] = location.y.toFloat()
         obj["z"] = location.z.toFloat()

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/PlayerSerializer.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/PlayerSerializer.kt
@@ -5,6 +5,7 @@ import me.ebonjaeger.perworldinventory.data.PlayerProfile
 import net.minidev.json.JSONArray
 import net.minidev.json.JSONObject
 import org.bukkit.GameMode
+import org.bukkit.util.NumberConversions
 
 object PlayerSerializer
 {
@@ -77,8 +78,8 @@ object PlayerSerializer
                 stats["exp"] as Float,
                 stats["flying"] as Boolean,
                 stats["food"] as Int,
-                (stats["max-health"] as Float).toDouble(),
-                (stats["health"] as Float).toDouble(),
+                NumberConversions.toDouble(stats["max-health"]),
+                NumberConversions.toDouble(stats["health"]),
                 GameMode.valueOf(stats["gamemode"] as String),
                 stats["level"] as Int,
                 stats["saturation"] as Float,

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/PotionSerializer.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/PotionSerializer.kt
@@ -17,16 +17,14 @@ object PotionSerializer
      * @param effects The PotionEffects to serialize
      * @return The serialized PotionEffects
      */
+    @Suppress("UNCHECKED_CAST") // We know that #serialize will give us a Map for a ConfigurationSerializable object
     fun serialize(effects: MutableCollection<PotionEffect>): JSONArray
     {
         val array = JSONArray()
 
         effects.forEach { effect ->
-            val obj = JSONObject()
-
-            obj["effect"] = SerializationHelper.serialize(effect)
-
-            array.add(obj)
+            val map = SerializationHelper.serialize(effect) as Map<String, Any>
+            array.add(JSONObject(map))
         }
 
         return array
@@ -38,7 +36,6 @@ object PotionSerializer
      * @param array The serialized PotionEffects
      * @return The PotionEffects
      */
-    @Suppress("UNCHECKED_CAST") // Reading a map we created; it's safe to assume the Map types
     fun deserialize(array: JSONArray): MutableCollection<PotionEffect>
     {
         val effects = mutableListOf<PotionEffect>()
@@ -47,8 +44,8 @@ object PotionSerializer
         {
             val obj = array[i] as JSONObject
 
-            val effect = if (obj["effect"] is Map<*, *> && (obj["effect"] as Map<*, *>).containsKey("==")) { // Object is a Map, and contains the classname as a key
-                val map = obj["effect"] as Map<String, Any>
+            val effect = if (obj.containsKey("==")) { // Object contains the classname as a key
+                val map = obj as Map<String, Any>
                 SerializationHelper.deserialize(map) as PotionEffect
             } else { // Likely older data, try to use the old long way
                 deserializeLongWay(obj)

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
@@ -23,9 +23,6 @@ class BukkitService @Inject constructor(private val plugin: PerWorldInventory)
     fun getOfflinePlayers(): Array<out OfflinePlayer> =
             Bukkit.getOfflinePlayers()
 
-    fun getServerVersion(): String =
-        plugin.server.version
-
     fun runRepeatingTaskAsynchronously(task: Runnable, delay: Long, period: Long): BukkitTask =
             scheduler.runTaskTimerAsynchronously(plugin, task, delay, period)
 
@@ -44,7 +41,4 @@ class BukkitService @Inject constructor(private val plugin: PerWorldInventory)
 
     fun runTask(task: () -> Unit): BukkitTask =
         scheduler.runTask(plugin, task)
-
-    fun shouldUseAttributes() =
-            Utils.checkServerVersion(getServerVersion(), 1, 11, 0)
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/service/EconomyService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/service/EconomyService.kt
@@ -54,7 +54,7 @@ class EconomyService @Inject constructor(private val server: Server,
                     if (response.errorMessage.equals("Loan was not permitted", true))
                     {
                         ConsoleLogger.warning("[ECON] Negative balances are not permitted. Setting balance for '${player.name}'" +
-                                " to 0 in '${player.location.world.name}'")
+                                " to 0 in '${player.location.world?.name}'")
                         econ.withdrawPlayer(player, oldBalance)
                     } else
                     {

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventoryInitializationTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventoryInitializationTest.kt
@@ -39,6 +39,7 @@ import org.powermock.modules.junit4.PowerMockRunner
 import java.io.File
 import java.util.logging.Logger
 import kotlin.reflect.KClass
+import kotlin.test.fail
 
 
 /**
@@ -61,11 +62,13 @@ class PerWorldInventoryInitializationTest {
     private lateinit var pluginManager: PluginManager
 
     private lateinit var pluginFolder: File
+    private lateinit var pluginFile: File
     private lateinit var plugin: PerWorldInventory
 
     @Before
     fun mockServer() {
         pluginFolder = temporaryFolder.newFolder()
+        pluginFile = temporaryFolder.newFile()
 
         setField(Bukkit::class, null, "server", server)
         given(server.logger).willReturn(mock(Logger::class.java))
@@ -79,7 +82,7 @@ class PerWorldInventoryInitializationTest {
         val descriptionFile = PluginDescriptionFile(
                 "PerWorldInventory", "N/A", PerWorldInventory::class.java.canonicalName)
         val pluginLoader = JavaPluginLoader(server)
-        plugin = PerWorldInventory(pluginLoader, descriptionFile, pluginFolder, null)
+        plugin = PerWorldInventory(pluginLoader, descriptionFile, pluginFolder, pluginFile)
         setField(JavaPlugin::class, plugin, "logger", mock(PluginLogger::class.java))
     }
 
@@ -108,7 +111,9 @@ class PerWorldInventoryInitializationTest {
 
     private fun verifyListenerWasRegistered(clazz: KClass<out Listener>, injector: Injector) {
         val listener = injector.getIfAvailable(clazz)
-        assertThat("Listener available for $clazz", listener, not(nullValue()))
+        if (listener === null) {
+            fail("Listener not available for '$clazz'")
+        }
         Mockito.verify(pluginManager).registerEvents(listener, plugin)
     }
 

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/ItemMetaImpl.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/ItemMetaImpl.kt
@@ -1,9 +1,14 @@
 package me.ebonjaeger.perworldinventory.serialization
 
+import com.google.common.collect.Multimap
+import org.bukkit.attribute.Attribute
+import org.bukkit.attribute.AttributeModifier
 import org.bukkit.enchantments.Enchantment
+import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.inventory.ItemFlag
 import org.bukkit.inventory.meta.Damageable
 import org.bukkit.inventory.meta.ItemMeta
+import org.bukkit.inventory.meta.tags.CustomItemTagContainer
 
 /**
  * Implementation of [ItemMeta] for usage in tests.
@@ -14,6 +19,8 @@ import org.bukkit.inventory.meta.ItemMeta
 class ItemMetaTestImpl : ItemMeta, Damageable {
 
     val providedMap: MutableMap<String, Any>
+
+    private var version = 0
 
     /**
      * Default constructor.
@@ -42,19 +49,11 @@ class ItemMetaTestImpl : ItemMeta, Damageable {
         throw NotImplementedError("not implemented")
     }
 
-    override fun addEnchant(ench: Enchantment?, level: Int, ignoreLevelRestriction: Boolean): Boolean {
-        throw NotImplementedError("not implemented")
-    }
-
     override fun getLore(): MutableList<String> {
         throw NotImplementedError("not implemented")
     }
 
     override fun setLore(lore: MutableList<String>?) {
-        throw NotImplementedError("not implemented")
-    }
-
-    override fun hasConflictingEnchant(ench: Enchantment?): Boolean {
         throw NotImplementedError("not implemented")
     }
 
@@ -86,10 +85,6 @@ class ItemMetaTestImpl : ItemMeta, Damageable {
         throw NotImplementedError("not implemented")
     }
 
-    override fun getEnchantLevel(ench: Enchantment?): Int {
-        throw NotImplementedError("not implemented")
-    }
-
     override fun spigot(): ItemMeta.Spigot {
         throw NotImplementedError("not implemented")
     }
@@ -102,10 +97,6 @@ class ItemMetaTestImpl : ItemMeta, Damageable {
         throw NotImplementedError("not implemented")
     }
 
-    override fun hasEnchant(ench: Enchantment?): Boolean {
-        throw NotImplementedError("not implemented")
-    }
-
     override fun getLocalizedName(): String {
         throw NotImplementedError("not implemented")
     }
@@ -115,14 +106,6 @@ class ItemMetaTestImpl : ItemMeta, Damageable {
     }
 
     override fun removeItemFlags(vararg itemFlags: ItemFlag?) {
-        throw NotImplementedError("not implemented")
-    }
-
-    override fun hasItemFlag(flag: ItemFlag?): Boolean {
-        throw NotImplementedError("not implemented")
-    }
-
-    override fun removeEnchant(ench: Enchantment?): Boolean {
         throw NotImplementedError("not implemented")
     }
 
@@ -142,6 +125,86 @@ class ItemMetaTestImpl : ItemMeta, Damageable {
 
     override fun setDamage(damage: Int)
     {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun addEnchant(ench: Enchantment, level: Int, ignoreLevelRestriction: Boolean): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun hasConflictingEnchant(ench: Enchantment): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun getCustomModelData(): Int {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun setAttributeModifiers(attributeModifiers: Multimap<Attribute, AttributeModifier>?) {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun removeAttributeModifier(attribute: Attribute): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun removeAttributeModifier(slot: EquipmentSlot): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun removeAttributeModifier(attribute: Attribute, modifier: AttributeModifier): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun hasCustomModelData(): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun addAttributeModifier(attribute: Attribute, modifier: AttributeModifier): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun getEnchantLevel(ench: Enchantment): Int {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun setVersion(version: Int) {
+        this.version = version
+    }
+
+    override fun hasEnchant(ench: Enchantment): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun setCustomModelData(data: Int?) {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun hasAttributeModifiers(): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun getCustomTagContainer(): CustomItemTagContainer {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun hasItemFlag(flag: ItemFlag): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun removeEnchant(ench: Enchantment): Boolean {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun getAttributeModifiers(): Multimap<Attribute, AttributeModifier>? {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun getAttributeModifiers(slot: EquipmentSlot): Multimap<Attribute, AttributeModifier> {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun getAttributeModifiers(attribute: Attribute): MutableCollection<AttributeModifier> {
         throw NotImplementedError("not implemented")
     }
 }

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/ItemMetaImpl.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/ItemMetaImpl.kt
@@ -9,6 +9,7 @@ import org.bukkit.inventory.ItemFlag
 import org.bukkit.inventory.meta.Damageable
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.tags.CustomItemTagContainer
+import org.bukkit.persistence.PersistentDataContainer
 
 /**
  * Implementation of [ItemMeta] for usage in tests.
@@ -205,6 +206,10 @@ class ItemMetaTestImpl : ItemMeta, Damageable {
     }
 
     override fun getAttributeModifiers(attribute: Attribute): MutableCollection<AttributeModifier> {
+        throw NotImplementedError("not implemented")
+    }
+
+    override fun getPersistentDataContainer(): PersistentDataContainer {
         throw NotImplementedError("not implemented")
     }
 }

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializerTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializerTest.kt
@@ -45,7 +45,7 @@ class LocationSerializerTest
 
     private fun assertHasSameProperties(given: Location, expected: Location)
     {
-        assertThat(given.world.name, equalTo(expected.world.name))
+        assertThat(given.world!!.name, equalTo(expected.world!!.name)) // We created them, we know they're not null!
         assertThat(given.x.toFloat(), equalTo(expected.x.toFloat()))
         assertThat(given.y.toFloat(), equalTo(expected.y.toFloat()))
         assertThat(given.z.toFloat(), equalTo(expected.z.toFloat()))

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializerTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/LocationSerializerTest.kt
@@ -2,6 +2,7 @@ package me.ebonjaeger.perworldinventory.serialization
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import net.minidev.json.JSONObject
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.World
@@ -41,6 +42,30 @@ class LocationSerializerTest
         // then
         val result = LocationSerializer.deserialize(json)
         assertHasSameProperties(result, loc)
+    }
+
+    @Test
+    fun deserializedOldDataCorrectly() {
+        // given
+        val world = mock(World::class.java)
+        given(Bukkit.getWorld("test")).willReturn(world)
+        given(world.name).willReturn("test")
+
+        val expected = Location(world, 14521.3, 14.0, -2352.121, 123.3F, -2352.532F)
+
+        val obj = JSONObject()
+        obj["world"] = "test"
+        obj["x"] = 14521.3
+        obj["y"] = 14.0
+        obj["z"] = -2352.121
+        obj["yaw"] = 123.3F
+        obj["pitch"] = -2352.532F
+
+        // when
+        val actual = LocationSerializer.deserialize(obj)
+
+        // then
+        assertHasSameProperties(actual, expected)
     }
 
     private fun assertHasSameProperties(given: Location, expected: Location)

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/PlayerSerializerTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/serialization/PlayerSerializerTest.kt
@@ -31,6 +31,8 @@ import org.powermock.modules.junit4.PowerMockRunner
 class PlayerSerializerTest
 {
 
+    private lateinit var unsafe: UnsafeValues
+
     @Before
     fun prepareTestingStuff()
     {
@@ -47,9 +49,14 @@ class PlayerSerializerTest
 
         // As of 1.13, Bukkit has a compatibility layer, and serializing an item
         // now checks the data version to see what Material name to use.
-        val unsafe = PowerMockito.mock(UnsafeValues::class.java)
+        unsafe = PowerMockito.mock(UnsafeValues::class.java)
         BDDMockito.given(Bukkit.getUnsafe()).willReturn(unsafe)
         BDDMockito.given(unsafe.dataVersion).willReturn(1513)
+        given(unsafe.getMaterial("AIR", 1513)).willReturn(Material.AIR)
+        given(unsafe.getMaterial("DIAMOND", 1513)).willReturn(Material.DIAMOND)
+        given(unsafe.getMaterial("DIAMOND_CHESTPLATE", 1513)).willReturn(Material.DIAMOND_CHESTPLATE)
+        given(unsafe.getMaterial("IRON_LEGGINGS", 1513)).willReturn(Material.IRON_LEGGINGS)
+        given(unsafe.getMaterial("GOLDEN_APPLE", 1513)).willReturn(Material.GOLDEN_APPLE)
     }
 
     @Test


### PR DESCRIPTION
All of the code changes necessary for 1.14.

This may all work on 1.13, however, the main focus is on 1.14.
Most of the code changes are tweaking/fixing the handling of nullability since Spigot decided to add nullability annotations to the entire API. Some of them are a bit silly. Yay...

One *actual* change is that PotionEffects will be serialized by their `ConfigurationSerializable` method going forward. This increases our maintainability since it now becomes the server's problem to deal with it, not us. If it breaks, it's a server bug.

EDIT: Locations are now also being serialized by the `Location#serialize()` method. Once PlayerProfile being ConfigurationSerializable becomes a thing, I would like to have a startup task automatically convert all old data to the current format, so we can get rid of the old backward-compatability deserialization methods.

This is not to be merged until the API has an official 1.14 version (currently 1.14-pre5 at the time of writing). Additional tweaks and dependency updates (if any) may still occur.