### PR TITLE
remove useless keepLevel in favor of keepInventory

### DIFF
--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerDeathListener.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/listener/player/PlayerDeathListener.kt
@@ -27,10 +27,6 @@ class PlayerDeathListener @Inject constructor(private val groupManager: GroupMan
         if (!event.keepInventory)
         {
             player.inventory.clear()
-        }
-
-        if (!event.keepLevel)
-        {
             player.totalExperience = event.newExp
             player.level = event.newLevel
         }


### PR DESCRIPTION
Hello,

I got an issue with Gamerule **keepinventory**. On **player death**, inventory is keep but not xp level.
I check PWI codes and found an old value used: **keepLevel**.

An issue on spigot was open, md5 answer is clear:
https://hub.spigotmc.org/jira/browse/SPIGOT-2222

This PR closes issues:
fix https://github.com/EbonJaeger/perworldinventory-kt/issues/109
fix https://github.com/EbonJaeger/perworldinventory-kt/issues/120

Tested on 1.13.2. 
**NOT tested in 1.8**

Thanks.